### PR TITLE
Add category view and cart actions

### DIFF
--- a/src/app/(general)/categoria/[categoria]/page.tsx
+++ b/src/app/(general)/categoria/[categoria]/page.tsx
@@ -1,0 +1,45 @@
+import { Producto } from "@/interfaces/producto.interface";
+import { promises as fs } from "fs";
+import { AddToCartButton } from "@/components/cart/add-to-cart-button";
+import Link from "next/link";
+
+export default async function CategoriaPage({ params }: { params: { categoria: string } }) {
+  const file = await fs.readFile(process.cwd() + "/src/data/listado_productos_GA.json", "utf8");
+  const productos: Producto[] = JSON.parse(file);
+  const productosFiltrados = productos
+    .map((p, idx) => ({ ...p, id: idx }))
+    .filter((p) => p.categoria.toLowerCase() === decodeURIComponent(params.categoria).toLowerCase());
+
+  return (
+    <main className="p-4 space-y-4">
+      <h2 className="text-xl font-semibold capitalize">
+        {decodeURIComponent(params.categoria)}
+      </h2>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm border">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="px-4 py-2 text-left">Nombre</th>
+              <th className="px-4 py-2 text-left">Precio USD</th>
+              <th className="px-4 py-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {productosFiltrados.map((p) => (
+              <tr key={p.id} className="border-t">
+                <td className="px-4 py-2">{p.nombre}</td>
+                <td className="px-4 py-2">${p.precio_usd}</td>
+                <td className="px-4 py-2 text-right">
+                  <AddToCartButton product={{ id: p.id, name: p.nombre, price: parseFloat(p.precio_usd.replace(',', '.')) }} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <Link href="/" className="text-sm underline">
+        ← Volver
+      </Link>
+    </main>
+  );
+}

--- a/src/app/(general)/page.tsx
+++ b/src/app/(general)/page.tsx
@@ -1,6 +1,7 @@
 import { Card } from "@/components/ui/card";
 import { Producto } from "@/interfaces/producto.interface";
 import { promises as fs } from "fs";
+import Link from "next/link";
 export default async function GeneralPage() {
 
 
@@ -11,16 +12,19 @@ export default async function GeneralPage() {
 
   return (
     <main className="h-full">
-      <header className="p-8 my-4">
-        <h2 className="text-center text-2xl">¿Qué vas a comprar hoy?</h2>
+      <header className="p-8 my-4 text-center space-y-2">
+        <h1 className="text-3xl font-bold">Bienvenido a GA Alberdi</h1>
+        <p className="text-muted-foreground">¿Qué vas a comprar hoy?</p>
       </header>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 p-4">
-          {uniqueCategories.map((category) => (
-            <Card key={category} className="grid place-items-center hover:shadow-lg transition-shadow duration-300">
-              <h3 className="text-lg font-semibold uppercase ">{category}</h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 p-4">
+        {uniqueCategories.map((category) => (
+          <Link key={category} href={`/categoria/${encodeURIComponent(category)}`}> 
+            <Card className="p-6 grid place-items-center hover:shadow-lg transition-shadow cursor-pointer">
+              <h3 className="text-lg font-semibold uppercase">{category}</h3>
             </Card>
-          ))}
-        </div> 
+          </Link>
+        ))}
+      </div>
     </main>
   );
 }

--- a/src/components/cart/add-to-cart-button.tsx
+++ b/src/components/cart/add-to-cart-button.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { useCartStore } from "@/lib/store/cart-store";
+import { Button } from "@/components/ui/button";
+
+interface ProductInfo {
+  id: number;
+  name: string;
+  price: number;
+}
+
+export function AddToCartButton({ product }: { product: ProductInfo }) {
+  const addItem = useCartStore((state) => state.addItem);
+
+  return (
+    <Button size="sm" onClick={() => addItem(product)}>
+      Agregar
+    </Button>
+  );
+}

--- a/src/lib/store/cart-store.ts
+++ b/src/lib/store/cart-store.ts
@@ -4,11 +4,11 @@ import { persist } from "zustand/middleware"
 interface Product {
   id: number
   name: string
-  description: string
   price: number
-  image: string
-  category: string
-  inStock: boolean
+  description?: string
+  image?: string
+  category?: string
+  inStock?: boolean
 }
 
 interface CartItem extends Product {


### PR DESCRIPTION
## Summary
- link categories from the home page
- add a button component to add products to cart
- create page to show products by category with cart actions
- simplify cart store interface for dataset

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686adee25c90832ab967cc439ac2c874